### PR TITLE
Add multistatus channels

### DIFF
--- a/src/commands/notify.js
+++ b/src/commands/notify.js
@@ -1,10 +1,23 @@
 const { isOfBaseType } = require('../util.js');
 
+const { Update } = require('../structs/Update.js');
+
 const call = async function(message, parts) {
   if (!message.client.updateCache.has(message.channel.id)) return await message.channel.send(`No update message for this channel`);
 
   let added = true;
   let update = message.client.updateCache.get(message.channel.id);
+  if (isOfBaseType(update, Array)) {
+    if (update.length === 1) {
+      update = update[0];
+    } else {
+      return await message.channel.send('Sorry the notify command is disabled for multistatus channels'); // NOTE: Players cannot disable notifications after there are multiple statuses
+    }
+  } else if (!isOfBaseType(update, Update)) {
+    console.error('Bad update type', update);
+    return; // Ahhh something has gone wrong
+  }
+
   let user = message.author.id, name;
 
   if (parts.length < 1) {

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -11,7 +11,15 @@ const call = async function(message, parts) {
 
   await update.send(message.client, 0);
 
-  message.client.updateCache.set(update.channel, update);
+  if (message.client.updateCache.has(update.channel)) {
+    let old = message.client.updateCache.get(update.channel);
+    if (!Array.isArray(old)) old = [old];
+    old.push(update);
+    await message.client.updateCache.set(update.channel, old);
+  } else {
+    await message.client.updateCache.set(update.channel, [update]);
+  }
+
 
   // await message.delete();
 }

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,13 @@ client.on('cUpdate', errorWrap(async function() {
 }))
 
 async function doUpdate(update, tick) {
-  await update.send(client, tick);
+  if (Array.isArray(update)) {
+    for (let u of update) {
+      await u.send(client, tick);
+    }
+  } else {
+    await update.send(client, tick);
+  }
 }
 
 async function start(config) {

--- a/src/structs/save/SaveJSON.js
+++ b/src/structs/save/SaveJSON.js
@@ -34,7 +34,7 @@ class SaveJSON extends SaveInterface {
       for (let i in item) {
         await this.saveItem(obj[key], i, item[i]);
       }
-    } else if (isOfBaseType(item, Serializable)) {
+    } else if (item instanceof Serializable) {
       obj[key] = item.serialize();
     }
     return true;

--- a/src/structs/save/SaveJSON.js
+++ b/src/structs/save/SaveJSON.js
@@ -1,7 +1,8 @@
 const fs = require('fs').promises;
 const SaveInterface = require('./SaveInterface.js');
 const Update = require('../Update.js');
-const { allSettled } = require('../../util.js');
+const Serializable = require('../Serializable.js');
+const { allSettled, isOfBaseType } = require('../../util.js');
 
 class SaveJSON extends SaveInterface {
   constructor(filename) {
@@ -23,8 +24,19 @@ class SaveJSON extends SaveInterface {
   }
 
   async saveItem(obj, key, item) {
-    // if (!(item instanceof Serializable)) return false;
-    obj[key] = item.serialize();
+    if (isOfBaseType(item, Array)) {
+      obj[key] = new Array(item.length);
+      for (let i=0;i<item.length;i++) {
+        await this.saveItem(obj[key], i, item[i]);
+      }
+    } else if (isOfBaseType(item, Object)) { // NOTE: Maybe we shouldn't deal with this cases as Serializables are transformed into objects
+      obj[key] = {};
+      for (let i in item) {
+        await this.saveItem(obj[key], i, item[i]);
+      }
+    } else if (isOfBaseType(item, Serializable)) {
+      obj[key] = item.serialize();
+    }
     return true;
   }
 
@@ -44,7 +56,16 @@ class SaveJSON extends SaveInterface {
   }
 
   async loadItem(updateCache, key, item) {
-    updateCache.set(key, Update.parse(item), true);
+    let res; // NOTE: Type checking here is a bit flippant
+    if (isOfBaseType(item, Array)) {
+      res = new Array(item.length);
+      for (let i=0;i<item.length;i++) {
+        res[i] = Update.parse(item[i]);
+      }
+    } else {
+      res = Update.parse(item);
+    }
+    updateCache.set(key, res, true);
     return true;
   }
 }


### PR DESCRIPTION
[Card](https://github.com/Douile/discord-gamestatus/projects/1#card-3562037)

Adds support for multiple status embeds in a single channel, notify command is disabled for channels with multiple statuses. When using statusclear all statuses in the channel will be cleared.

Should be backwards compatible with save files.